### PR TITLE
feat(footer.js): mainsite footer shows different hardcoded site sections

### DIFF
--- a/src/common/slanted-borders-helpers.js
+++ b/src/common/slanted-borders-helpers.js
@@ -5,6 +5,4 @@ export const SlantedBorderElement = styled.div`
   /* Your styling goes here */
 
   clip-path: polygon(0 20px, 100% 0, 100% 100%, 0 100%);
-  margin-top: -20px;
-  padding-top: 62px;
 `

--- a/src/common/slanted-borders-helpers.js
+++ b/src/common/slanted-borders-helpers.js
@@ -5,6 +5,6 @@ export const SlantedBorderElement = styled.div`
   /* Your styling goes here */
 
   clip-path: polygon(0 20px, 100% 0, 100% 100%, 0 100%);
-  margin-top: -20px;
-  padding-top: 62px;
+  margin-top: -50px;
+  padding: 10px;
 `

--- a/src/common/slanted-borders-helpers.js
+++ b/src/common/slanted-borders-helpers.js
@@ -5,6 +5,6 @@ export const SlantedBorderElement = styled.div`
   /* Your styling goes here */
 
   clip-path: polygon(0 20px, 100% 0, 100% 100%, 0 100%);
-  margin-top: -50px;
-  padding: 10px;
+  margin-top: -20px;
+  padding-top: 62px;
 `

--- a/src/common/slanted-borders-helpers.js
+++ b/src/common/slanted-borders-helpers.js
@@ -5,4 +5,6 @@ export const SlantedBorderElement = styled.div`
   /* Your styling goes here */
 
   clip-path: polygon(0 20px, 100% 0, 100% 100%, 0 100%);
+  margin-top: -20px;
+  padding-top: 62px;
 `

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -7,6 +7,7 @@ import { InnerWrapper } from "./layout"
 import { SlantedBorderElement } from "../common/slanted-borders-helpers"
 import colors from "../common/colors"
 import breakpoints from "../common/breakpoints"
+import fonts from "../common/fonts"
 
 const FooterElement = styled(SlantedBorderElement)`
   background: ${colors.backgrounds.footer};
@@ -29,7 +30,7 @@ const LinkTitle = styled(Link)`
 const SiteTitle = styled(Link)`
   text-decoration: none;
   color: ${colors.typography.dark};
-  font-family: Poppins;
+  font-family: ${fonts.logoFont};
   font-size: 36px;
   font-weight: normal;
 `

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -6,18 +6,60 @@ import styled from "styled-components"
 import { InnerWrapper } from "./layout"
 import { SlantedBorderElement } from "../common/slanted-borders-helpers"
 import colors from "../common/colors"
+import breakpoints from "../common/breakpoints"
 
 const FooterElement = styled(SlantedBorderElement)`
   background: ${colors.backgrounds.footer};
+  padding-bottom: 15px;
 `
 
-const Footer = ({ siteTitle }) => (
+const PageElements = styled.div`
+  display: flex;
+  justify-content: center; 
+  flex-wrap: wrap;
+`;
+
+const LinkTitle = styled(Link)`
+  text-decoration: none;
+  color: black;
+`;
+
+const SiteTitle = styled(Link)`
+  text-decoration: none;
+  color: black;
+  font-family: 'Poppins'; 
+  font-size: '36px'; 
+  font-weight: 'normal';
+`;
+
+
+const PageElement = styled.div`
+  display: inline-block;
+  color: black;
+  margin: 10px;
+
+  @media (min-width: ${breakpoints.tablet}px) {
+    margin: 30px;
+  }
+`;
+
+const Footer = ({ siteTitle, pages }) => (
   <FooterElement as="footer">
     <InnerWrapper>
       <div>
-        <h4>
-          <Link to="/">{siteTitle}</Link>
-        </h4>
+        <PageElements>
+        {pages.map(page => 
+        <PageElement id={page}>
+          <LinkTitle to={"/" + page}>
+            <h4>{page}</h4>
+          </LinkTitle>
+        </PageElement>)}
+        </PageElements>
+        <PageElements>
+          <h4>
+            <SiteTitle to="/">{siteTitle}</SiteTitle>
+          </h4>
+        </PageElements>
       </div>
     </InnerWrapper>
   </FooterElement>

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -27,9 +27,9 @@ const LinkTitle = styled(Link)`
 const SiteTitle = styled(Link)`
   text-decoration: none;
   color: black;
-  font-family: "Poppins";
-  font-size: "36px";
-  font-weight: "normal";
+  font-family: Poppins;
+  font-size: 36px;
+  font-weight: normal;
 `
 
 const PageElement = styled.div`

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -15,23 +15,22 @@ const FooterElement = styled(SlantedBorderElement)`
 
 const PageElements = styled.div`
   display: flex;
-  justify-content: center; 
+  justify-content: center;
   flex-wrap: wrap;
-`;
+`
 
 const LinkTitle = styled(Link)`
   text-decoration: none;
   color: black;
-`;
+`
 
 const SiteTitle = styled(Link)`
   text-decoration: none;
   color: black;
-  font-family: 'Poppins'; 
-  font-size: '36px'; 
-  font-weight: 'normal';
-`;
-
+  font-family: "Poppins";
+  font-size: "36px";
+  font-weight: "normal";
+`
 
 const PageElement = styled.div`
   display: inline-block;
@@ -41,19 +40,20 @@ const PageElement = styled.div`
   @media (min-width: ${breakpoints.tablet}px) {
     margin: 30px;
   }
-`;
+`
 
 const Footer = ({ siteTitle, pages }) => (
   <FooterElement as="footer">
     <InnerWrapper>
       <div>
         <PageElements>
-        {pages.map(page => 
-        <PageElement id={page}>
-          <LinkTitle to={"/" + page}>
-            <h4>{page}</h4>
-          </LinkTitle>
-        </PageElement>)}
+          {pages.map(page => (
+            <PageElement id={page}>
+              <LinkTitle to={"/" + page}>
+                <h4>{page}</h4>
+              </LinkTitle>
+            </PageElement>
+          ))}
         </PageElements>
         <PageElements>
           <h4>

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -11,6 +11,8 @@ import breakpoints from "../common/breakpoints"
 const FooterElement = styled(SlantedBorderElement)`
   background: ${colors.backgrounds.footer};
   padding-bottom: 15px;
+  padding-top: 62px;
+  margin-top: -20px;
 `
 
 const PageElements = styled.div`

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -23,12 +23,12 @@ const PageElements = styled.div`
 
 const LinkTitle = styled(Link)`
   text-decoration: none;
-  color: black;
+  color: ${colors.typography.dark};
 `
 
 const SiteTitle = styled(Link)`
   text-decoration: none;
-  color: black;
+  color: ${colors.typography.dark};
   font-family: Poppins;
   font-size: 36px;
   font-weight: normal;
@@ -36,7 +36,7 @@ const SiteTitle = styled(Link)`
 
 const PageElement = styled.div`
   display: inline-block;
-  color: black;
+  color: ${colors.typography.dark};
   margin: 10px;
 
   @media (min-width: ${breakpoints.tablet}px) {

--- a/src/components/getting-started.js
+++ b/src/components/getting-started.js
@@ -1,7 +1,5 @@
-import React, { Component } from "react"
+import React from "react"
 
-import { Layout } from "../components/layout"
-import SEO from "../components/seo"
 import styled from "styled-components"
 import colors from "../common/colors"
 import { SlantedBorderElement } from "../common/slanted-borders-helpers.js"

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -53,7 +53,10 @@ const _Layout = ({ children }) => {
       >
         <main>{children}</main>
       </div>
-      <Footer siteTitle={data.site.siteMetadata.title} pages={["Features", "Support", "News", "Login", "Sign Up"]} />
+      <Footer
+        siteTitle={data.site.siteMetadata.title}
+        pages={["Features", "Support", "News", "Login", "Sign Up"]}
+      />
     </>
   )
 }

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -53,7 +53,7 @@ const _Layout = ({ children }) => {
       >
         <main>{children}</main>
       </div>
-      <Footer siteTitle={data.site.siteMetadata.title} />
+      <Footer siteTitle={data.site.siteMetadata.title} pages={["Features", "Support", "News", "Login", "Sign Up"]} />
     </>
   )
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,4 @@
 import React from "react"
-import { Link } from "gatsby"
 
 import { Layout } from "../components/layout"
 import Image from "../components/image"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -13,7 +13,6 @@ const IndexPage = () => (
       <Image />
       <GettingStartedComponent />
     </div>
-    <Link to="/getting-started">Go to page 3</Link>
   </Layout>
 )
 

--- a/src/templates/newsTemplate.js
+++ b/src/templates/newsTemplate.js
@@ -4,8 +4,6 @@ import { graphql } from "gatsby"
 import { Layout } from "../components/layout"
 import SEO from "../components/seo"
 
-import styled from "styled-components"
-
 export default function Template({
   data, // this prop will be injected by the GraphQL query below.
 }) {


### PR DESCRIPTION
The mainsite has an slanted border helper that separates the sections. The footer includes the site
sections that are hardcoded on the index. Should be responsive, however its looking like there is a
bug in the header that throws off some responsiveness. Will fix in a separate PR.

re #21